### PR TITLE
Add exec-builder

### DIFF
--- a/bin/exec-builder
+++ b/bin/exec-builder
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DOCKER_CLI_HINTS=false docker exec -it \
+  --user couchbase \
+  --env HOME=/home/couchbase \
+  --workdir $(pwd) \
+  builder \
+  "$@"


### PR DESCRIPTION
Provides a different way of interacting with the container. Instead of having to drop into an interactive Docker session, one can just execute the desired command into the container by running in their native shell session:

```
  exec-builder cmake -GNinja ..
```

It lets me use my macOS shell:

```
dev/master-debug-linux/build via △ v3.30.2 took 4m9s
❯ exec-builder ninja
[27/983] Building CXX object couchstore/CMakeFiles/couchstore_view_objs.dir/Unity/unity_1_cxx.cxx.o
```